### PR TITLE
Fix for running also on a cygwin environment

### DIFF
--- a/tls-setup/Makefile
+++ b/tls-setup/Makefile
@@ -1,7 +1,8 @@
 .PHONY: cfssl ca req clean
 
-CFSSL	= @env PATH=$(GOPATH)/bin:$(PATH) cfssl
-JSON	= env PATH=$(GOPATH)/bin:$(PATH) cfssljson
+GOPATH  = .
+CFSSL	= @env PATH=$(GOPATH)/bin cfssl
+JSON	= env PATH=$(GOPATH)/bin cfssljson
 
 all: ca req
 


### PR DESCRIPTION
It thows the following error on a cygwin environment without this change:

```
/bin/sh: -c: line 0: syntax error near unexpected token `('
```

and the path environment is not needed ?!

I tested it for 'ca' and 'req' tasks on cygwin.
